### PR TITLE
Header와 메인의 분배 받은 파트 작업을 끝냈습니다.

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -13,21 +13,28 @@
 <body>
 
   <!--@ 헤더 -->
-  <header class="max-w-[1920px] flex gap-5 bg-gray-800">
-    <h1 class="h-[42px] w-[132px] bg-red-300"><a href="#"
-        class="bg-[url('/images/icon-logo.svg')] bg-no-repeat w-full h-full block bg-cover"></a></h1>
-    <ol class="flex items-center gap-3 bg-orange-200">
-      <li><a href="#" class="inline-block h-[28px]"><img src="./images/icon-tv.svg" alt=""
-            class="inline-block -translate-y-[10%] bg-yellow-400 h-[18px]" /><span
-            class="leading-[28px] bg-green-300">실시간</span></a></li>
-      <li><a href="#" class="bg-blue-400">TV프로그램</a></li>
-      <li><a href="#" class="bg-blue-800">영화</a></li>
-      <li><a href="#"><img src="./images/icon-paramount.svg" alt="" /></a></li>
-    </ol>
-    <div class="flex ml-auto align-middle">
-      <img src="./images/icon-search.svg" alt="검색" class="h-[bg-yellow-700" />
-      <img src="./images/profile-4.jpg" alt="마이페이지" class="w-[34px] h-[32px]" />
-    </div>
+  <header class="max-w-[1920px] mx-auto h-[100px] desktop:h-[100px] tablet:h-[56px] mobile:h-[38px] flex gap-12 px-[4.375rem] sticky top-0 bg-black backdrop-blur-lg">
+    <h1 class="w-[6.875vw] min-w-[46px] max-w-[132px] h-full">
+      <a href="#" aria-label="타빙" class="block w-full h-full bg-[url('/images/icon-logo.svg')] bg-no-repeat bg-contain bg-center"></a>
+    </h1>
+    <ul class="order-2 ml-auto flex items-center gap-[2vw]">
+      <li class="w-[2vw] min-w-[18px] max-w-[40px] col-span-1"><img src="./images/icon-search.svg" alt="검색" /></li>
+      <li class="w-[2vw] min-w-[18px] max-w-[40px] col-start-3 col-end-4"><img src="./images/profile-4.jpg" alt="마이페이지" /></li>
+    </ul>
+    <nav class="flex items-center mobile:hidden">
+      <h2 class="sr-only">메인 메뉴</h2>
+      <ol class="flex items-center gap-12">
+        <li>
+          <a href="#" class="inline-block h-[28px] whitespace-nowrap">
+            <img src="./images/icon-tv.svg" alt="" class="inline-block -translate-y-[10%] h-[18px]" />
+            <span class="text-base leading-7">실시간</span>
+          </a>
+        </li>
+        <li><a href="#" class="text-base whitespace-nowrap">TV프로그램</a></li>
+        <li><a href="#" class="text-base whitespace-nowrap">영화</a></li>
+        <li class="w-[5.83vw] min-w-[65px] max-w-[112px]"><a href="#" class="w-full h-full"><img src="./images/icon-paramount.svg" alt="파라마운트 플러스" /></a></li>
+      </ol>
+    </nav>
   </header>
 
   <!--@ 아티클 -->
@@ -57,8 +64,8 @@
   <br />
 
   <!--@ 메인 -->
-  <main class="px-[70px] max-w-full mx-auto">
-    <!--$첫번째 줄-->
+  <main class="pl-[70px] max-w-full mx-auto">
+    <!-- $첫번째 줄 -->
     <section>
       <h1 class="mb-3 font__clamp mobile:text-left tablet:text-center desktop:text-right">티빙에서 꼭 봐야하는 콘텐츠</h1>
       <div class="flex gap-4 pb-9 overflow-hidden min-w-[760px]">
@@ -179,7 +186,43 @@
       </div>
     </section>
 
+    <!-- $다섯번째 줄 -->
+    <section class="py-9 overflow-y-hidden scroll">
+      <h2>오직 티빙에만 있어요</h2>
+      <ul class="mt-3 flex gap-4 mobile:gap-2">
+        <li class="shrink-0 w-[14.8vw] min-w-[139px] max-w-[285px]"><a href="#"><img src="./images/only-1.jpg" alt="전체관람가:숏버스터" class="rounded-lg" /></a></li>
+        <li class="shrink-0 w-[14.8vw] min-w-[139px] max-w-[285px]"><a href="#"><img src="./images/only-2.jpg" alt="러브캐처 인 발리" class="rounded-lg" /></a></li>
+        <li class="shrink-0 w-[14.8vw] min-w-[139px] max-w-[285px]"><a href="#"><img src="./images/only-3.jpg" alt="환승연애" class="rounded-lg" /></a></li>
+        <li class="shrink-0 w-[14.8vw] min-w-[139px] max-w-[285px]"><a href="#"><img src="./images/only-4.jpg" alt="몸값" class="rounded-lg" /></a></li>
+        <li class="shrink-0 w-[14.8vw] min-w-[139px] max-w-[285px]"><a href="#"><img src="./images/only-5.jpg" alt="술꾼도시여자들" class="rounded-lg" /></a></li>
+        <li class="shrink-0 w-[14.8vw] min-w-[139px] max-w-[285px]"><a href="#"><img src="./images/only-6.jpg" alt="괴이" class="rounded-lg" /></a></li>
+        <li class="shrink-0 w-[14.8vw] min-w-[139px] max-w-[285px]"><a href="#"><img src="./images/only-7.jpg" alt="푸드크로니클" class="rounded-lg" /></a></li>
+      </ul>
+    </section>
+
+    <!-- $여섯번째 줄 -->
+    <section class="py-9">
+      <h2 class="sr-only">광고</h2>
+      <figure class="min-w-[304px] max-w-[1780px]">
+        <img src="./images/sports-1.jpg" />
+      </figure>
+      <figcaption class="sr-only">타빙 스포츠 경기 생중계 UFC 월드복싱 슈퍼매치 분데스리가 AFC 챔피언스리그</figcaption>
+    </section>
+    
+    <!-- $일곱번째 줄 -->
+      <section>
+        <h2>이벤트</h2>
+        <ul class="mt-3 flex gap-[10px] overflow-y-hidden scroll">
+          <li class="shrink-0 w-[18vw] min-w-[145px] max-w-[346px]"><a href="#"><img src="./images/event-1.jpg" alt="신비아파트 극장 개봉 기념 예매권 증정 이벤트" class="rounded-md" /></a></li>
+          <li class="shrink-0 w-[18vw] min-w-[145px] max-w-[346px]"><a href="#"><img src="./images/event-2.jpg" alt="재벌집 막내아들 시청하고 1일 재벌체험 하세요" class="rounded-md" /></a></li>
+          <li class="shrink-0 w-[18vw] min-w-[145px] max-w-[346px]"><a href="#"><img src="./images/event-3.jpg" alt="환승연애 시즌투의 진한 여운을 잇는 과몰입 도파민 충전 이벤트" class="rounded-md" /></a></li>
+          <li class="shrink-0 w-[18vw] min-w-[145px] max-w-[346px]"><a href="#"><img src="./images/event-4.jpg" alt="슈룹 지금 시청하고 공식 우산굿즈 받아가세요" class="rounded-md" /></a></li>
+          <li class="shrink-0 w-[18vw] min-w-[145px] max-w-[346px]"><a href="#"><img src="./images/event-5.jpg" alt="대한민국 대표 디저트 메이커를 찾습니다" class="rounded-md" /></a></li>
+          <li class="shrink-0 w-[18vw] min-w-[145px] max-w-[346px]"><a href="#"><img src="./images/event-6.jpg" alt="소설 원작 렛미인 지금 감상하고, 원작 도서 세트 받자" class="rounded-md" /></a></li>
+        </ul>
+      </section>
   </main>
+
 
 
   <!--@ 푸터 -->

--- a/src/style/index.css
+++ b/src/style/index.css
@@ -4,7 +4,7 @@
 
 body {
   color: #c4c4c4;
-  background: #2b2b2b;
+  background: black;
   font-size: clamp(0.75rem, 0.6rem + 0.75vw, 1.5rem);
 }
 
@@ -13,4 +13,7 @@ body {
   font-size: clamp(0.75rem, 0.6rem + 0.75vw, 1.5rem);
 }
 
+.scroll::-webkit-scrollbar {
+  display: none;
+}
 /*# sourceMappingURL=index.css.map */

--- a/src/style/style.css
+++ b/src/style/style.css
@@ -542,12 +542,36 @@ video {
   position: relative;
 }
 
+.sticky {
+  position: sticky;
+}
+
+.top-0 {
+  top: 0px;
+}
+
 .top-1\/2 {
   top: 50%;
 }
 
 .top-3\/4 {
   top: 75%;
+}
+
+.order-2 {
+  order: 2;
+}
+
+.col-span-1 {
+  grid-column: span 1 / span 1;
+}
+
+.col-start-3 {
+  grid-column-start: 3;
+}
+
+.col-end-4 {
+  grid-column-end: 4;
 }
 
 .mx-auto {
@@ -604,6 +628,10 @@ video {
   margin-top: 0.5rem;
 }
 
+.mt-3 {
+  margin-top: 0.75rem;
+}
+
 .mt-\[27px\] {
   margin-top: 27px;
 }
@@ -624,20 +652,16 @@ video {
   height: 10%;
 }
 
+.h-\[100px\] {
+  height: 100px;
+}
+
 .h-\[18px\] {
   height: 18px;
 }
 
 .h-\[28px\] {
   height: 28px;
-}
-
-.h-\[32px\] {
-  height: 32px;
-}
-
-.h-\[42px\] {
-  height: 42px;
 }
 
 .h-\[52px\] {
@@ -656,16 +680,28 @@ video {
   width: 1000px;
 }
 
-.w-\[132px\] {
-  width: 132px;
+.w-\[14\.8vw\] {
+  width: 14.8vw;
 }
 
-.w-\[34px\] {
-  width: 34px;
+.w-\[18vw\] {
+  width: 18vw;
+}
+
+.w-\[2vw\] {
+  width: 2vw;
+}
+
+.w-\[5\.83vw\] {
+  width: 5.83vw;
 }
 
 .w-\[52px\] {
   width: 52px;
+}
+
+.w-\[6\.875vw\] {
+  width: 6.875vw;
 }
 
 .w-full {
@@ -676,16 +712,68 @@ video {
   min-width: 1000px;
 }
 
+.min-w-\[139px\] {
+  min-width: 139px;
+}
+
+.min-w-\[145px\] {
+  min-width: 145px;
+}
+
+.min-w-\[18px\] {
+  min-width: 18px;
+}
+
+.min-w-\[304px\] {
+  min-width: 304px;
+}
+
+.min-w-\[46px\] {
+  min-width: 46px;
+}
+
+.min-w-\[65px\] {
+  min-width: 65px;
+}
+
 .min-w-\[760px\] {
   min-width: 760px;
+}
+
+.max-w-\[112px\] {
+  max-width: 112px;
+}
+
+.max-w-\[132px\] {
+  max-width: 132px;
+}
+
+.max-w-\[1780px\] {
+  max-width: 1780px;
 }
 
 .max-w-\[1920px\] {
   max-width: 1920px;
 }
 
+.max-w-\[285px\] {
+  max-width: 285px;
+}
+
+.max-w-\[346px\] {
+  max-width: 346px;
+}
+
+.max-w-\[40px\] {
+  max-width: 40px;
+}
+
 .max-w-full {
   max-width: 1920px;
+}
+
+.shrink-0 {
+  flex-shrink: 0;
 }
 
 .-translate-y-\[10\%\] {
@@ -709,8 +797,8 @@ video {
   gap: 0.25rem;
 }
 
-.gap-3 {
-  gap: 0.75rem;
+.gap-12 {
+  gap: 3rem;
 }
 
 .gap-4 {
@@ -721,8 +809,32 @@ video {
   gap: 1.25rem;
 }
 
+.gap-\[10px\] {
+  gap: 10px;
+}
+
+.gap-\[2vw\] {
+  gap: 2vw;
+}
+
 .overflow-hidden {
   overflow: hidden;
+}
+
+.overflow-y-hidden {
+  overflow-y: hidden;
+}
+
+.whitespace-nowrap {
+  white-space: nowrap;
+}
+
+.rounded-lg {
+  border-radius: 0.5rem;
+}
+
+.rounded-md {
+  border-radius: 0.375rem;
 }
 
 .border-t {
@@ -734,56 +846,30 @@ video {
   border-top-color: rgb(107 107 107 / var(--tw-border-opacity));
 }
 
-.bg-blue-400 {
+.bg-black {
   --tw-bg-opacity: 1;
-  background-color: rgb(96 165 250 / var(--tw-bg-opacity));
-}
-
-.bg-blue-800 {
-  --tw-bg-opacity: 1;
-  background-color: rgb(30 64 175 / var(--tw-bg-opacity));
-}
-
-.bg-gray-800 {
-  --tw-bg-opacity: 1;
-  background-color: rgb(31 41 55 / var(--tw-bg-opacity));
-}
-
-.bg-green-300 {
-  --tw-bg-opacity: 1;
-  background-color: rgb(134 239 172 / var(--tw-bg-opacity));
-}
-
-.bg-orange-200 {
-  --tw-bg-opacity: 1;
-  background-color: rgb(254 215 170 / var(--tw-bg-opacity));
-}
-
-.bg-red-300 {
-  --tw-bg-opacity: 1;
-  background-color: rgb(252 165 165 / var(--tw-bg-opacity));
-}
-
-.bg-yellow-400 {
-  --tw-bg-opacity: 1;
-  background-color: rgb(250 204 21 / var(--tw-bg-opacity));
-}
-
-.bg-yellow-700 {
-  --tw-bg-opacity: 1;
-  background-color: rgb(161 98 7 / var(--tw-bg-opacity));
+  background-color: rgb(0 0 0 / var(--tw-bg-opacity));
 }
 
 .bg-\[url\(\'\/images\/icon-logo\.svg\'\)\] {
   background-image: url('/images/icon-logo.svg');
 }
 
-.bg-cover {
-  background-size: cover;
+.bg-contain {
+  background-size: contain;
+}
+
+.bg-center {
+  background-position: center;
 }
 
 .bg-no-repeat {
   background-repeat: no-repeat;
+}
+
+.px-\[4\.375rem\] {
+  padding-left: 4.375rem;
+  padding-right: 4.375rem;
 }
 
 .px-\[68px\] {
@@ -791,9 +877,9 @@ video {
   padding-right: 68px;
 }
 
-.px-\[70px\] {
-  padding-left: 70px;
-  padding-right: 70px;
+.py-9 {
+  padding-top: 2.25rem;
+  padding-bottom: 2.25rem;
 }
 
 .pb-9 {
@@ -804,17 +890,22 @@ video {
   padding-bottom: 170px;
 }
 
-.pt-\[140px\] {
-  padding-top: 140px;
+.pl-\[70px\] {
+  padding-left: 70px;
 }
 
-.align-middle {
-  vertical-align: middle;
+.pt-\[140px\] {
+  padding-top: 140px;
 }
 
 .text-3xl {
   font-size: 1.875rem;
   line-height: 2.25rem;
+}
+
+.text-base {
+  font-size: 1rem;
+  line-height: 1.5rem;
 }
 
 .text-xl {
@@ -831,8 +922,8 @@ video {
   font-style: normal;
 }
 
-.leading-\[28px\] {
-  line-height: 28px;
+.leading-7 {
+  line-height: 1.75rem;
 }
 
 .text-gray-100 {
@@ -859,9 +950,15 @@ video {
   text-decoration-line: underline;
 }
 
+.backdrop-blur-lg {
+  --tw-backdrop-blur: blur(16px);
+  -webkit-backdrop-filter: var(--tw-backdrop-blur) var(--tw-backdrop-brightness) var(--tw-backdrop-contrast) var(--tw-backdrop-grayscale) var(--tw-backdrop-hue-rotate) var(--tw-backdrop-invert) var(--tw-backdrop-opacity) var(--tw-backdrop-saturate) var(--tw-backdrop-sepia);
+          backdrop-filter: var(--tw-backdrop-blur) var(--tw-backdrop-brightness) var(--tw-backdrop-contrast) var(--tw-backdrop-grayscale) var(--tw-backdrop-hue-rotate) var(--tw-backdrop-invert) var(--tw-backdrop-opacity) var(--tw-backdrop-saturate) var(--tw-backdrop-sepia);
+}
+
 body {
   color: #c4c4c4;
-  background: #2b2b2b;
+  background: black;
   font-size: clamp(0.75rem, 0.6rem + 0.75vw, 1.5rem);
 }
 
@@ -871,19 +968,43 @@ body {
   font-size: clamp(0.75rem, 0.6rem + 0.75vw, 1.5rem);
 }
 
+.scroll::-webkit-scrollbar {
+  display: none;
+}
+
 @media (min-width: 320px) and (max-width: 767px) {
+  .mobile\:hidden {
+    display: none;
+  }
+
+  .mobile\:h-\[38px\] {
+    height: 38px;
+  }
+
+  .mobile\:gap-2 {
+    gap: 0.5rem;
+  }
+
   .mobile\:text-left {
     text-align: left;
   }
 }
 
 @media (min-width: 768px) and (max-width: 1199px) {
+  .tablet\:h-\[56px\] {
+    height: 56px;
+  }
+
   .tablet\:text-center {
     text-align: center;
   }
 }
 
 @media (min-width: 1200px) and (max-width: 1920px) {
+  .desktop\:h-\[100px\] {
+    height: 100px;
+  }
+
   .desktop\:text-right {
     text-align: right;
   }


### PR DESCRIPTION
### [진행 상황]
**Header**
- 시맨틱 마크업을 위해 `ol`을 `nav`의 자식요소로 변경하였습니다.
- 접근성을 고려하여 `nav`와 `'검색+프로필'`의 마크업 순서를 바꾸고 스타일링으로 디자인상의 위치를 만들어주었습니다.
- 논의가 필요한 부분 외에는 모두 완성하였습니다.
- 논의가 필요한 부분 : 폰트 크기, 디바이스별 헤더 디자인 변화

**Main(각자 배분 파트)**
- 배분 받은 3개의 section을 완성하였습니다.
- 3개의 section : '오직 티빙에만 있어요', 축구 광고 배너, 이벤트 

**merge 완료**
- develop에 올려주신 승민님의 작업을 pull로 가져와, 위의 작업물과 merge 하였습니다.

**기타 사항**
- settings.json의 파일이 변경되어 병합 출동이 발생하길래 수락하였습니다.